### PR TITLE
Migrate logging (and debug println's) to SLF4J.

### DIFF
--- a/AgentServices-Store/src/main/scala/com/protegra_ati/agentservices/protocols/introduction/IntroductionInitiator.scala
+++ b/AgentServices-Store/src/main/scala/com/protegra_ati/agentservices/protocols/introduction/IntroductionInitiator.scala
@@ -7,27 +7,25 @@ import com.protegra_ati.agentservices.protocols.msgs._
 import java.util.UUID
 
 trait IntroductionInitiatorT extends Serializable {
+
+  /**
+    * Define a logger used within the protocol.
+    * @note You can instantiate one with org.slf4j.LoggerFactory.getLogger(classOf[yourclass])
+    * @return
+    */
+  def logger: org.slf4j.Logger
+
   def run(
     node: Being.AgentKVDBNode[PersistedKVDBNodeRequest, PersistedKVDBNodeResponse],
     cnxns: Seq[PortableAgentCnxn],
     filters: Seq[CnxnCtxtLabel[String, String, String]]
   ): Unit = {
-    // println(
-//       (
-//         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-//         + "\nIntroductionInitiator -- entering run method " 
-//         + "\nnode: " + node
-//         + "\ncnxns: " + cnxns
-//         + "\nfilters " + filters
-//         + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-//       )
-//     )
     if (cnxns.size != 1) throw new Exception("invalid number of cnxns supplied")
 
     val protocolMgr = new ProtocolManager(node)
     val aliasCnxn = cnxns(0)
 
-    println(
+    logger.debug(
       (
         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
         + "\nIntroductionInitiator -- invoking listenBeginIntroductionRequest " 
@@ -43,7 +41,7 @@ trait IntroductionInitiatorT extends Serializable {
   private def listenBeginIntroductionRequest(protocolMgr: ProtocolManager, aliasCnxn: PortableAgentCnxn): Unit = {
     // listen for BeginIntroductionRequest message
     val beginIntroRqLabel = BeginIntroductionRequest.toLabel()
-    println(
+    logger.debug(
       (
         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
         + "\nIntroductionInitiator -- waiting for BeginIntroductionRequest " 
@@ -55,7 +53,7 @@ trait IntroductionInitiatorT extends Serializable {
     )
     protocolMgr.subscribeMessage(aliasCnxn, beginIntroRqLabel, {
       case bIRRq@BeginIntroductionRequest(sessionId, PortableAgentBiCnxn(aReadCnxn, aWriteCnxn), PortableAgentBiCnxn(bReadCnxn, bWriteCnxn), aMessage, bMessage) => {
-        println(
+        logger.debug(
           (
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
             + "\nIntroductionInitiator -- received BeginIntroductionRequest " 
@@ -68,7 +66,7 @@ trait IntroductionInitiatorT extends Serializable {
         )
         val aGetIntroProfileRq = GetIntroductionProfileRequest(sessionId, UUID.randomUUID.toString, aReadCnxn)
 
-        println(
+        logger.debug(
           (
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
             + "\nIntroductionInitiator -- sending A's GetIntroductionProfileRequest " 
@@ -85,8 +83,8 @@ trait IntroductionInitiatorT extends Serializable {
         
         // listen for A's GetIntroductionProfileResponse message
         val aGetIntroProfileRspLabel = GetIntroductionProfileResponse.toLabel(sessionId, aGetIntroProfileRq.correlationId)
-        
-        println(
+
+        logger.debug(
           (
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
             + "\nIntroductionInitiator -- waiting for A's GetIntroductionProfileResponse " 
@@ -98,7 +96,7 @@ trait IntroductionInitiatorT extends Serializable {
         )
         protocolMgr.getMessage(aReadCnxn, aGetIntroProfileRspLabel, {
           case aGIRPRsp@GetIntroductionProfileResponse(_, _, aProfileData) => {
-            println(
+            logger.debug(
               (
                 "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                 + "\nIntroductionInitiator -- received A's GetIntroductionProfileResponse " 
@@ -111,7 +109,7 @@ trait IntroductionInitiatorT extends Serializable {
               )
             )
             val bGetIntroProfileRq = GetIntroductionProfileRequest(sessionId, UUID.randomUUID.toString, bReadCnxn)
-            println(
+            logger.debug(
               (
                 "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                 + "\nIntroductionInitiator -- sending B's GetIntroductionProfileRequest " 
@@ -129,8 +127,8 @@ trait IntroductionInitiatorT extends Serializable {
             
             // listen for B's GetIntroductionProfileResponse message
             val bGetIntroProfileRspLabel = GetIntroductionProfileResponse.toLabel(sessionId, bGetIntroProfileRq.correlationId)
-            
-            println(
+
+            logger.debug(
               (
                 "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                 + "\nIntroductionInitiator -- waiting for B's GetIntroductionProfileResponse " 
@@ -142,7 +140,7 @@ trait IntroductionInitiatorT extends Serializable {
             )
             protocolMgr.getMessage(bReadCnxn, bGetIntroProfileRspLabel, {          
               case bGIRPRsp@GetIntroductionProfileResponse(_, _, bProfileData) => {
-                println(
+                logger.debug(
                   (
                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                     + "\nIntroductionInitiator -- received B's GetIntroductionProfileResponse " 
@@ -154,8 +152,8 @@ trait IntroductionInitiatorT extends Serializable {
                   )
                 )
                 val aIntroRq = IntroductionRequest(sessionId, UUID.randomUUID.toString, aReadCnxn, aMessage, bProfileData)
-                
-                println(
+
+                logger.debug(
                   (
                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                     + "\nIntroductionInitiator -- sending A's IntroductionRequest " 
@@ -172,7 +170,7 @@ trait IntroductionInitiatorT extends Serializable {
                 
                 // listen for A's IntroductionResponse message
                 val aIntroRspLabel = IntroductionResponse.toLabel(sessionId, aIntroRq.correlationId)
-                println(
+                logger.debug(
                   (
                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                     + "\nIntroductionInitiator -- waiting for A's IntroductionResponse " 
@@ -185,7 +183,7 @@ trait IntroductionInitiatorT extends Serializable {
                 
                 protocolMgr.getMessage(aReadCnxn, aIntroRspLabel, {
                   case aIR@IntroductionResponse(_, _, aAccepted, aConnectCorrelationId) => {
-                    println(
+                    logger.debug(
                       (
                         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                         + "\nIntroductionInitiator -- received A's IntroductionResponse " 
@@ -197,8 +195,8 @@ trait IntroductionInitiatorT extends Serializable {
                       )
                     )
                     val bIntroRq = IntroductionRequest(sessionId, UUID.randomUUID.toString, bReadCnxn, bMessage, aProfileData)
-                    
-                    println(
+
+                    logger.debug(
                       (
                         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                         + "\nIntroductionInitiator -- sending b's IntroductionRequest " 
@@ -215,7 +213,7 @@ trait IntroductionInitiatorT extends Serializable {
                     
                     // listen for B's IntroductionResponse message
                     val bIntroRspLabel = IntroductionResponse.toLabel(sessionId, bIntroRq.correlationId)
-                    println(
+                    logger.debug(
                       (
                         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                         + "\nIntroductionInitiator -- waiting for B's IntroductionResponse " 
@@ -228,7 +226,7 @@ trait IntroductionInitiatorT extends Serializable {
                     
                     protocolMgr.getMessage(bReadCnxn, bIntroRspLabel, {
                       case bIR@IntroductionResponse(_, _, bAccepted, bConnectCorrelationId) => {
-                        println(
+                        logger.debug(
                           (
                             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                             + "\nIntroductionInitiator -- received B's IntroductionResponse " 
@@ -239,9 +237,9 @@ trait IntroductionInitiatorT extends Serializable {
                             + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                           )
                         )
-                        
-                        
-                        println(
+
+
+                        logger.debug(
                           (
                             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                             + "\nIntroductionInitiator -- checking transaction status " 
@@ -271,7 +269,7 @@ trait IntroductionInitiatorT extends Serializable {
                           val aConnect = Connect(sessionId, aConnectCorrelationId.get, false, Some(aNewBiCnxn))
                           val bConnect = Connect(sessionId, bConnectCorrelationId.get, false, Some(bNewBiCnxn))
                           
-                          println(
+                          logger.debug(
                             (
                               "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                               + "\nIntroductionInitiator -- sending both Connect Msgs" 
@@ -290,16 +288,8 @@ trait IntroductionInitiatorT extends Serializable {
                           protocolMgr.putMessage(aWriteCnxn, aConnect)
                           protocolMgr.putMessage(bWriteCnxn, bConnect)
                         } else if (aAccepted) {
-                          // println(
-//                             (
-//                               "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-//                               + "\nIntroductionInitiator -- A committed; B didn't " 
-//                               + "\nnode: " + protocolMgr.node
-//                               + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-//                             )
-//                           )
                           val aConnect = Connect(sessionId, aConnectCorrelationId.get, true, None)
-                          println(
+                          logger.debug(
                             (
                               "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                               + "\nIntroductionInitiator -- alerting A's UI" 
@@ -314,16 +304,8 @@ trait IntroductionInitiatorT extends Serializable {
                           // send Connect message
                           protocolMgr.putMessage(aWriteCnxn, aConnect)
                         } else if (bAccepted) {
-                          // println(
-//                             (
-//                               "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-//                               + "\nIntroductionInitiator -- B committed; A didn't " 
-//                               + "\nnode: " + protocolMgr.node
-//                               + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-//                             )
-//                           )
                           val bConnect = Connect(sessionId, bConnectCorrelationId.get, true, None)
-                          println(
+                          logger.debug(
                             (
                               "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                               + "\nIntroductionInitiator -- alerting B's UI" 
@@ -353,6 +335,9 @@ trait IntroductionInitiatorT extends Serializable {
 }
 
 class IntroductionInitiator extends IntroductionInitiatorT {
+
+  val logger = org.slf4j.LoggerFactory.getLogger(classOf[IntroductionInitiator])
+
   override def run(
     kvdbNode: Being.AgentKVDBNode[PersistedKVDBNodeRequest, PersistedKVDBNodeResponse],
     cnxns: Seq[PortableAgentCnxn],

--- a/AgentServices-Store/src/main/scala/com/protegra_ati/agentservices/protocols/introduction/ProtocolManager.scala
+++ b/AgentServices-Store/src/main/scala/com/protegra_ati/agentservices/protocols/introduction/ProtocolManager.scala
@@ -9,6 +9,9 @@ import scala.util.continuations._
 
 class ProtocolManager(val node: Being.AgentKVDBNode[PersistedKVDBNodeRequest, PersistedKVDBNodeResponse]) extends Serializable {
   def this() = { this( null.asInstanceOf[Being.AgentKVDBNode[PersistedKVDBNodeRequest, PersistedKVDBNodeResponse]] ) }
+
+  private val logger = org.slf4j.LoggerFactory.getLogger(classOf[ProtocolManager])
+
   private def toAgentCnxn(cnxn: PortableAgentCnxn): acT.AgentCnxn = {
     acT.AgentCnxn(cnxn.src, cnxn.label, cnxn.trgt)
   }
@@ -46,7 +49,7 @@ class ProtocolManager(val node: Being.AgentKVDBNode[PersistedKVDBNodeRequest, Pe
       val agentCnxn = toAgentCnxn(cnxn)
 
       for (e <- node.get(agentCnxn)(filter)) {
-        println(
+        logger.debug(
           (
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
             + "\nProtocolMgr -- getMessage | get returned " 
@@ -81,17 +84,6 @@ class ProtocolManager(val node: Being.AgentKVDBNode[PersistedKVDBNodeRequest, Pe
       val agentCnxn = toAgentCnxn(cnxn)
 
       for (e <- node.subscribe(agentCnxn)(filter)) {
-        // println(
-//           (
-//             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-//             + "\nProtocolMgr -- subscribeMessage | subscribe returned " 
-//             + "\nnode: " + node
-//             + "\ncnxn: " + cnxn
-//             + "\nfilter: " + filter
-//             + "\ne: " + e
-//             + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-//           )
-//         )
         e match {
           // colocated 
           case Some(mTT.Ground(PostedExpr(message: ProtocolMessage))) =>
@@ -127,17 +119,6 @@ class ProtocolManager(val node: Being.AgentKVDBNode[PersistedKVDBNodeRequest, Pe
       val agentCnxn = toAgentCnxn(cnxn)
 
       for (e <- node.get(agentCnxn)(filter)) {
-        // println(
-//           (
-//             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-//             + "\nProtocolMgr -- get | get returned " 
-//             + "\nnode: " + node
-//             + "\ncnxn: " + cnxn
-//             + "\nfilter: " + filter
-//             + "\ne: " + e
-//             + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-//           )
-//         )
         onResult(e)
       }
     }

--- a/AgentServices-Store/src/main/scala/com/protegra_ati/agentservices/protocols/reputation/ContentRecipient.scala
+++ b/AgentServices-Store/src/main/scala/com/protegra_ati/agentservices/protocols/reputation/ContentRecipient.scala
@@ -21,22 +21,19 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
   import com.biosimilarity.evaluator.distribution.utilities.DieselValueTrampoline._
   import com.protegra_ati.agentservices.store.extensions.StringExtensions._
 
+  /**
+    * Define a logger used within the protocol.
+    * @note You can instantiate one with org.slf4j.LoggerFactory.getLogger(classOf[yourclass])
+    * @return
+    */
+  def logger: org.slf4j.Logger
+
   def run(
     node : Being.AgentKVDBNode[PersistedKVDBNodeRequest, PersistedKVDBNodeResponse],
     cnxns : Seq[PortableAgentCnxn],
     filters : Seq[CnxnCtxtLabel[String, String, String]]
   ): Unit = {
-    BasicLogService.tweet(
-      (
-        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-        + "\ncontentRecipient -- behavior instantiated and run method invoked " 
-        + "\nnode: " + node
-        + "\ncnxns: " + cnxns
-        + "\nfilters: " + filters
-        + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-      )
-    )
-    println(
+    logger.debug(
       (
         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
         + "\ncontentRecipient -- behavior instantiated and run method invoked " 
@@ -64,19 +61,10 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
           }
 
         for( ( agntCnxn, _ ) <- agntRecipientCnxnsRdWr ) {
-          BasicLogService.tweet(
+          logger.debug(
             (
               "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
               + "\ncontentRecipient -- waiting for content publication on: " 
-              + "\nagntCnxn: " + agntCnxn
-              + "\nlabel: " + PublishWithReo.toLabel
-              + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-            )
-          )
-          println(
-            (
-              "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-              + "\nclaimant -- waiting for initiate claim on: " 
               + "\nagntCnxn: " + agntCnxn
               + "\nlabel: " + PublishWithReo.toLabel
               + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
@@ -87,16 +75,7 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
             for( ePublishWithReo <- node.subscribe( agntCnxn )( PublishWithReo.toLabel ) ) {
               rsrc2V[ReputationMessage]( ePublishWithReo ) match {
                 case Left( PublishWithReo( sidPC, cidPC, p2cPC, cntntPC, reoPC ) ) => {
-                  BasicLogService.tweet(
-                    (
-                      "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                      + "\ncontentRecipient -- received PublishWithReo request: " + ePublishWithReo
-                      + "\ncnxn: " + agntCnxn
-                      + "\nlabel: " + PublishWithReo.toLabel
-                      + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                    )
-                  )
-                  println(
+                  logger.debug(
                     (
                       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                       + "\ncontentRecipient -- received PublishWithReo request: " + ePublishWithReo
@@ -117,16 +96,7 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
                     rsrc2V[ReputationMessage]( eHashedConnections ) match
                     {
                       case Left( HashedConnections( sidPC, cidPC, seqOfCnxnsPC ) ) => {
-                        BasicLogService.tweet(
-                          (
-                            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                            + "\ncontentRecipient -- received HashedConnections request: " + eHashedConnections
-                            + "\ncnxn: " + agntCnxn
-                            + "\nlabel: " + HashedConnections.toLabel
-                            + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          )
-                        )
-                        println(
+                        logger.debug(
                           (
                             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                             + "\ncontentRecipient -- received HashedConnections request: " + eHashedConnections
@@ -148,16 +118,7 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
                           rsrc2V[ReputationMessage]( eIntersectionResult ) match
                           {
                             case Left( IntersectionResult( sidPC, cidPC, intersectCnxnsPC ) ) => {
-                              BasicLogService.tweet(
-                                (
-                                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                  + "\ncontentRecipient -- received IntersectionResult request: " + eIntersectionResult
-                                  + "\ncnxn: " + agntCnxn
-                                  + "\nlabel: " + IntersectionResult.toLabel
-                                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                )
-                              )
-                              println(
+                              logger.debug(
                                 (
                                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                                   + "\ncontentRecipient -- received IntersectionResult request: " + eIntersectionResult
@@ -167,17 +128,7 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
                                 )
                               )
                               if ( intersectionConnections != intersectCnxnsPC ) {
-                                BasicLogService.tweet(
-                                  (
-                                    "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                    + "\ncontentRecipient -- received IntersectionResult request: " + eIntersectionResult
-                                    + "\ncnxn: " + agntCnxn
-                                    + "\nlabel: " + IntersectionResult.toLabel
-                                    + "\nInvalid connection intersection"
-                                    + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                  )
-                                )
-                                println(
+                                logger.debug(
                                   (
                                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                                     + "\ncontentRecipient -- received IntersectionResult request: " + eIntersectionResult
@@ -194,14 +145,7 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
                               )
                               val reoScore : Int = 1000; // placeholder for actual calculation
                               if ( reoScore != reoPC ) {
-                                BasicLogService.tweet(
-                                  (
-                                    "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                    + "\nInvalid reo!!"
-                                    + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                  )
-                                )
-                                println(
+                                logger.debug(
                                   (
                                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                                     + "\nInvalid reo!!"
@@ -212,14 +156,7 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
                               // reo is good, continue to publish
                             }
                             case Right( true ) => {
-                              BasicLogService.tweet(
-                                (
-                                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                  + "\ncontentRecipient -- still waiting for IntersectionResult request"
-                                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                )
-                              )
-                              println(
+                              logger.debug(
                                 (
                                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                                   + "\ncontentRecipient -- still waiting for IntersectionResult request"
@@ -231,15 +168,7 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
                               // BUGBUG : lgm -- protect against strange and
                               // wondrous toString implementations (i.e. injection
                               // attack ) for eInitiateClaim
-                              BasicLogService.tweet(
-                                (
-                                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                  + "\ncontentRecipient -- while waiting for IntersectionResult request"
-                                  + "\nreceived unexpected protocol message : " + eIntersectionResult
-                                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                )
-                              )
-                              println(
+                              logger.debug(
                                 (
                                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                                   + "\ncontentRecipient -- while waiting for IntersectionResult request"
@@ -252,14 +181,7 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
                         }
                       }
                       case Right( true ) => {
-                        BasicLogService.tweet(
-                          (
-                            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                            + "\ncontentRecipient -- still waiting for HashedConnections request"
-                            + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          )
-                        )
-                        println(
+                        logger.debug(
                           (
                             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                             + "\ncontentRecipient -- still waiting for HashedConnections request"
@@ -271,15 +193,7 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
                         // BUGBUG : lgm -- protect against strange and
                         // wondrous toString implementations (i.e. injection
                         // attack ) for eInitiateClaim
-                        BasicLogService.tweet(
-                          (
-                            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                            + "\ncontentRecipient -- while waiting for HashedConnections request"
-                            + "\nreceived unexpected protocol message : " + eHashedConnections
-                            + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          )
-                        )
-                        println(
+                        logger.debug(
                           (
                             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                             + "\ncontentRecipient -- while waiting for HashedConnections request"
@@ -292,14 +206,7 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
                   }
                 }
                 case Right( true ) => {
-                  BasicLogService.tweet(
-                    (
-                      "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                      + "\ncontentRecipient -- still waiting for PublishWithReo request"
-                      + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                    )
-                  )
-                  println(
+                  logger.debug(
                     (
                       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                       + "\ncontentRecipient -- still waiting for PublishWithReo request"
@@ -311,15 +218,7 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
                   // BUGBUG : lgm -- protect against strange and
                   // wondrous toString implementations (i.e. injection
                   // attack ) for eInitiateClaim
-                  BasicLogService.tweet(
-                    (
-                      "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                      + "\ncontentRecipient -- while waiting for PublishWithReo request"
-                      + "\nreceived unexpected protocol message : " + ePublishWithReo
-                      + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                    )
-                  )
-                  println(
+                  logger.debug(
                     (
                       "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                       + "\ncontentRecipient -- while waiting for PublishWithReo request"
@@ -334,14 +233,7 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
         }         
       }
       case _ => {
-        BasicLogService.tweet(
-          (
-            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-            + "\ncontentRecipient -- at least one cnxn expected : " + cnxns
-            + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-          )
-        )
-        println(
+        logger.debug(
           (
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
             + "\ncontentRecipient -- at least one cnxn expected : " + cnxns
@@ -356,6 +248,9 @@ trait ContentRecipientBehaviorT extends ProtocolBehaviorT with Serializable {
 
 class ContentRecipientBehavior(
 ) extends ContentRecipientBehaviorT {
+
+  val logger = org.slf4j.LoggerFactory.getLogger(classOf[ContentRecipientBehavior])
+
   override def run(
     kvdbNode: Being.AgentKVDBNode[PersistedKVDBNodeRequest, PersistedKVDBNodeResponse],
     cnxns: Seq[PortableAgentCnxn],

--- a/AgentServices-Store/src/main/scala/com/protegra_ati/agentservices/protocols/verification/ClaimantBehavior.scala
+++ b/AgentServices-Store/src/main/scala/com/protegra_ati/agentservices/protocols/verification/ClaimantBehavior.scala
@@ -21,22 +21,19 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
   import com.biosimilarity.evaluator.distribution.utilities.DieselValueTrampoline._
   import com.protegra_ati.agentservices.store.extensions.StringExtensions._
 
+  /**
+    * Define a logger used within the protocol.
+    * @note You can instantiate one with org.slf4j.LoggerFactory.getLogger(classOf[yourclass])
+    * @return
+    */
+  def logger: org.slf4j.Logger
+
   def run(
     node : Being.AgentKVDBNode[PersistedKVDBNodeRequest, PersistedKVDBNodeResponse],
     cnxns : Seq[PortableAgentCnxn],
     filters : Seq[CnxnCtxtLabel[String, String, String]]
   ): Unit = {
-    BasicLogService.tweet(
-      (
-        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-        + "\nclaimant -- behavior instantiated and run method invoked " 
-        + "\nnode: " + node
-        + "\ncnxns: " + cnxns
-        + "\nfilters: " + filters
-        + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-      )
-    )
-    println(
+    logger.debug(
       (
         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
         + "\nclaimant -- behavior instantiated and run method invoked " 
@@ -59,16 +56,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
         val agntClmnt2GLoSWr =
           acT.AgentCnxn( clmnt2GLoS.trgt, clmnt2GLoS.label, clmnt2GLoS.src )
 
-        BasicLogService.tweet(
-          (
-            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-            + "\nclaimant -- waiting for initiate claim on: " 
-            + "\ncnxn: " + agntClmnt2GLoSRd
-            + "\nlabel: " + InitiateClaim.toLabel
-            + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-          )
-        )
-        println(
+        logger.debug(
           (
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
             + "\nclaimant -- waiting for initiate claim on: " 
@@ -81,17 +69,8 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
         reset {
           for( eInitiateClaim <- node.subscribe( agntClmnt2GLoSRd )( InitiateClaim.toLabel ) ) {
             rsrc2V[VerificationMessage]( eInitiateClaim ) match {
-              case Left( InitiateClaim( sidIC, cidIC, vrfrIC, rpIC, clmIC ) ) => { 
-                BasicLogService.tweet(
-                  (
-                    "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                    + "\nclaimant -- received initiate claim request: " + eInitiateClaim
-                    + "\ncnxn: " + agntClmnt2GLoSRd
-                    + "\nlabel: " + InitiateClaim.toLabel
-                    + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  )
-                )
-                println(
+              case Left( InitiateClaim( sidIC, cidIC, vrfrIC, rpIC, clmIC ) ) => {
+                logger.debug(
                   (
                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                     + "\nclaimant -- received initiate claim request: " + eInitiateClaim
@@ -108,16 +87,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
 
                 val avReq = AllowVerification( sidIC, cidIC, rpIC, clmIC )
 
-                BasicLogService.tweet(
-                  (
-                    "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                    + "\nclaimant -- publishing AllowVerification request: " + avReq
-                    + "\n on cnxn: " + agntVrfrWr
-                    + "\n label: " + AllowVerification.toLabel( sidIC )
-                    + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  )
-                )
-                println(
+                logger.debug(
                   (
                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                     + "\nclaimant -- publishing AllowVerification request: " + avReq
@@ -132,16 +102,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
                   avReq
                 )
 
-                BasicLogService.tweet(
-                  (
-                    "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                    + "\nclaimant -- waiting for allow verification acknowledgment on: " 
-                    + "\ncnxn: " + agntVrfrRd
-                    + "\nlabel: " + AckAllowVerification.toLabel( sidIC )
-                    + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  )
-                )
-                println(
+                logger.debug(
                   (
                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                     + "\nclaimant -- waiting for allow verification acknowledgment on: " 
@@ -152,17 +113,8 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
                 )
                 for( eAllowV <- node.subscribe( agntVrfrRd )( AckAllowVerification.toLabel( sidIC ) ) ) {
                   rsrc2V[VerificationMessage]( eAllowV ) match {
-                    case Left( AckAllowVerification( sidAAV, cidAAV, rpAAV, clmAAV ) ) => { 
-                      BasicLogService.tweet(
-                        (
-                          "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          + "\nclaimant -- received allow verification acknowledgment: " + eAllowV
-                          + "\ncnxn: " + agntVrfrRd
-                          + "\nlabel: " + AckAllowVerification.toLabel( sidIC )
-                          + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        )
-                      )
-                      println(
+                    case Left( AckAllowVerification( sidAAV, cidAAV, rpAAV, clmAAV ) ) => {
+                      logger.debug(
                         (
                           "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                           + "\nclaimant -- received allow verification acknowledgment: " + eAllowV
@@ -175,14 +127,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
                         sidAAV.equals( sidIC ) && cidAAV.equals( cidIC )
                         && rpAAV.equals( rpIC ) && clmAAV.equals( clmIC )
                       ) {
-                        BasicLogService.tweet(
-                          (
-                            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                            + "\nclaimant -- allow verification acknowledgment matches request" 
-                            + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          )
-                        )
-                        println(
+                        logger.debug(
                           (
                             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                             + "\nclaimant -- allow verification acknowledgment matches request" 
@@ -196,16 +141,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
 
                         val ocReq = OpenClaim( sidIC, cidIC, rpIC, clmIC )
 
-                        BasicLogService.tweet(
-                          (
-                            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                            + "\nclaimant -- publishing open claim request" + ocReq
-                            + "\ncnxn: " + agntRPRd
-                            + "\nlabel: " + OpenClaim.toLabel( sidIC )
-                            + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          )
-                        )
-                        println(
+                        logger.debug(
                           (
                             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                             + "\nclaimant -- publishing open claim request" + ocReq
@@ -222,16 +158,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
                           )            
                         }
 
-                        BasicLogService.tweet(
-                          (
-                            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                            + "\nclaimant -- waiting for close claim on: " 
-                            + "\ncnxn: " + agntRPRd
-                            + "\nlabel: " + CloseClaim.toLabel( sidIC )
-                            + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          )
-                        )
-                        println(
+                        logger.debug(
                           (
                             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                             + "\nclaimant -- waiting for close claim on: " 
@@ -243,15 +170,8 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
 
                         for( eCloseClaim <- node.subscribe( agntRPRd )( CloseClaim.toLabel( sidIC ) ) ) {
                           rsrc2V[VerificationMessage]( eCloseClaim ) match {
-                            case Left( CloseClaim( sidCC, cidCC, vrfrCC, clmCC, witCC ) ) => { 
-                              BasicLogService.tweet(
-                                (
-                                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                  + "\nclaimant -- received close claim message" + eCloseClaim
-                                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                )
-                              )
-                              println(
+                            case Left( CloseClaim( sidCC, cidCC, vrfrCC, clmCC, witCC ) ) => {
+                              logger.debug(
                                 (
                                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                                   + "\nclaimant -- received close claim message" + eCloseClaim
@@ -262,30 +182,14 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
                                 sidCC.equals( sidIC ) && cidCC.equals( cidIC )
                                 && vrfrCC.equals( rpIC ) && clmCC.equals( clmIC )
                               ) {
-                                BasicLogService.tweet(
+                                logger.debug(
                                   (
                                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                                     + "\nclaimant -- close claim message matches open claim request"
                                     + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                                   )
                                 )
-                                println(
-                                  (
-                                    "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                    + "\nclaimant -- close claim message matches open claim request"
-                                    + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                  )
-                                )
-                                BasicLogService.tweet(
-                                  (
-                                    "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                    + "\nclaimant -- publishing complete claim message"
-                                    + "\ncnxn: " + agntClmnt2GLoSWr
-                                    + "\nlabel: " + CompleteClaim.toLabel( sidIC )
-                                    + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                  )
-                                )
-                                println(
+                                logger.debug(
                                   (
                                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                                     + "\nclaimant -- publishing complete claim message"
@@ -300,22 +204,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
                                 )
                               }
                               else {
-                                BasicLogService.tweet(
-                                  (
-                                    "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                    + "\nclaimant -- close doesn't match open : " + eCloseClaim
-                                    + "\nsidIC : " + sidIC + " sidCC : " + sidCC
-                                    + "\nsidCC.equals( sidIC ) : " + sidCC.equals( sidIC )
-                                    + "\ncidIC : " + cidIC + " cidCC : " + cidCC
-                                    + "\ncidCC.equals( cidIC ) : " + cidCC.equals( cidIC )
-                                    + "\nrpIC : " + rpIC + " vrfrCC : " + vrfrCC
-                                    + "\nvrfrCC.equals( vrfrIC ) : " + vrfrCC.equals( vrfrIC )
-                                    + "\nclmIC : " + clmIC + "clmCC : " + clmCC
-                                    + "\nclmCC.equals( clmIC ) : " + clmCC.equals( clmIC )
-                                    + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                  )
-                                )
-                                println(
+                                logger.debug(
                                   (
                                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                                     + "\nclaimant -- close doesn't match open : " + eCloseClaim
@@ -359,15 +248,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
                               // BUGBUG : lgm -- protect against strange and
                               // wondrous toString implementations (i.e. injection
                               // attack ) for eInitiateClaim
-                              BasicLogService.tweet(
-                                (
-                                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                  + "\nclaimant -- while waiting for close claim"
-                                  + "\nunexpected protocol message : " + eCloseClaim
-                                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                                )
-                              )
-                              println(
+                              logger.debug(
                                 (
                                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                                   + "\nclaimant -- while waiting for close claim"
@@ -390,14 +271,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
                         }
                       }
                       else {
-                        BasicLogService.tweet(
-                          (
-                            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                            + "\nclaimant -- ack doesn't match : " + eAllowV
-                            + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          )
-                        )
-                        println(
+                        logger.debug(
                           (
                             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                             + "\nclaimant -- ack doesn't match : " + eAllowV
@@ -414,14 +288,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
                       }
                     }
                     case Right( true ) => {
-                      BasicLogService.tweet(
-                        (
-                          "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          + "\nclaimant -- still waiting for allow claim ack"
-                          + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        )
-                      )
-                      println(
+                      logger.debug(
                         (
                           "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                           + "\nclaimant -- still waiting for allow claim ack"
@@ -430,15 +297,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
                       )
                     }
                     case _ => {
-                      BasicLogService.tweet(
-                        (
-                          "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          + "\nclaimant -- while waiting for acknowledgment of allow verification"
-                          + "\nunexpected protocol message : " + eAllowV
-                          + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        )
-                      )
-                      println(
+                      logger.debug(
                         (
                           "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                           + "\nclaimant -- while waiting for acknowledgment of allow verification"
@@ -461,14 +320,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
                 }
               }
               case Right( true ) => {
-                BasicLogService.tweet(
-                  (
-                    "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                    + "\nclaimant -- still waiting for claim initiation"
-                    + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  )
-                )
-                println(
+                logger.debug(
                   (
                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                     + "\nclaimant -- still waiting for claim initiation"
@@ -480,15 +332,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
                 // BUGBUG : lgm -- protect against strange and
                 // wondrous toString implementations (i.e. injection
                 // attack ) for eInitiateClaim
-                BasicLogService.tweet(
-                  (
-                    "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                    + "\nclaimant -- while waiting for initiate claim"
-                    + "\nreceived unexpected protocol message : " + eInitiateClaim
-                    + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  )
-                )
-                println(
+                logger.debug(
                   (
                     "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                     + "\nclaimant -- while waiting for initiate claim"
@@ -512,14 +356,7 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
         }
       }
       case _ => {
-        BasicLogService.tweet(
-          (
-            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-            + "\nclaimant -- one cnxn expected : " + cnxns
-            + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-          )
-        )
-        println(
+        logger.debug(
           (
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
             + "\nclaimant -- one cnxn expected : " + cnxns
@@ -534,6 +371,9 @@ trait ClaimantBehaviorT extends ProtocolBehaviorT with Serializable {
 
 class ClaimantBehavior(
 ) extends ClaimantBehaviorT {
+
+  val logger = org.slf4j.LoggerFactory.getLogger(classOf[ClaimantBehavior])
+
   override def run(
     kvdbNode: Being.AgentKVDBNode[PersistedKVDBNodeRequest, PersistedKVDBNodeResponse],
     cnxns: Seq[PortableAgentCnxn],

--- a/AgentServices-Store/src/main/scala/com/protegra_ati/agentservices/protocols/verification/RelyingPartyBehavior.scala
+++ b/AgentServices-Store/src/main/scala/com/protegra_ati/agentservices/protocols/verification/RelyingPartyBehavior.scala
@@ -21,22 +21,19 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
   import com.biosimilarity.evaluator.distribution.utilities.DieselValueTrampoline._
   import com.protegra_ati.agentservices.store.extensions.StringExtensions._
 
+  /**
+    * Define a logger used within the protocol.
+    * @note You can instantiate one with org.slf4j.LoggerFactory.getLogger(classOf[yourclass])
+    * @return
+    */
+  def logger: org.slf4j.Logger
+
   def run(
     node : Being.AgentKVDBNode[PersistedKVDBNodeRequest, PersistedKVDBNodeResponse],
     cnxns : Seq[PortableAgentCnxn],
     filters : Seq[CnxnCtxtLabel[String, String, String]]
   ): Unit = {
-    BasicLogService.tweet(
-      (
-        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-        + "\nrelying party -- behavior instantiated and run method invoked " 
-        + "\nnode: " + node
-        + "\ncnxns: " + cnxns
-        + "\nfilters: " + filters
-        + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-      )
-    )
-    println(
+    logger.debug(
       (
         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
         + "\nrelying party -- behavior instantiated and run method invoked " 
@@ -65,16 +62,7 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
         }
       )
     for( ( cnxnRd, cnxnWr, pacCnxnRd ) <- agntCnxns ) {
-      BasicLogService.tweet(
-        (
-          "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-          + "\nrelying party -- waiting for open claim request on: " 
-          + "\ncnxn: " + cnxnRd
-          + "\nlabel: " + OpenClaim.toLabel
-          + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-        )
-      )
-      println(
+      logger.debug(
         (
           "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
           + "\nrelying party -- waiting for open claim request on: " 
@@ -86,17 +74,8 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
       reset {
         for( eOpenClaim <- node.subscribe( cnxnRd )( OpenClaim.toLabel ) ) {
           rsrc2V[VerificationMessage]( eOpenClaim ) match {
-            case Left( OpenClaim( sidOC, cidOC, vrfrOC, clmOC ) ) => { 
-              BasicLogService.tweet(
-                (
-                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  + "\nrelying party -- received open claim request: " + eOpenClaim
-                  + "\ncnxn: " + cnxnRd
-                  + "\nlabel: " + OpenClaim.toLabel
-                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                )
-              )
-              println(
+            case Left( OpenClaim( sidOC, cidOC, vrfrOC, clmOC ) ) => {
+              logger.debug(
                 (
                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                   + "\nrelying party -- received open claim request: " + eOpenClaim
@@ -113,16 +92,7 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
               val verifyRq = 
                 Verify( sidOC, cidOC, pacCnxnRd, clmOC )
 
-              BasicLogService.tweet(
-                (
-                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  + "\nrelying party -- publishing verify request: " + verifyRq
-                  + "\n on cnxn: " + agntVrfrWr
-                  + "\n label: " + Verify.toLabel( sidOC )
-                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                )
-              )
-              println(
+              logger.debug(
                 (
                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                   + "\nrelying party -- publishing verify request: " + verifyRq
@@ -137,16 +107,7 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
                 verifyRq
               )
 
-              BasicLogService.tweet(
-                (
-                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  + "\nrelying party -- waiting for verification testimony on: " 
-                  + "\ncnxn: " + agntVrfrRd
-                  + "\nlabel: " + Verification.toLabel
-                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                )
-              )
-              println(
+              logger.debug(
                 (
                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                   + "\nrelying party -- waiting for verification testimony on: " 
@@ -158,17 +119,8 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
 
               for( eVerification <- node.subscribe( agntVrfrRd )( Verification.toLabel ) ) {
                 rsrc2V[VerificationMessage]( eVerification ) match {
-                  case Left( Verification( sidV, cidV, clmntV, clmV, witV ) ) => { 
-                    BasicLogService.tweet(
-                      (
-                        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        + "\nrelying party -- received verification testimony: " + eVerification
-                        + "\ncnxn: " + agntVrfrRd
-                        + "\nlabel: " + Verification.toLabel
-                        + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                      )
-                    )
-                    println(
+                  case Left( Verification( sidV, cidV, clmntV, clmV, witV ) ) => {
+                    logger.debug(
                       (
                         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                         + "\nrelying party -- received verification testimony: " + eVerification
@@ -187,32 +139,15 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
                         VerificationNotification(
                           sidV, cidV, clmntV, clmV, witV
                         )
-                    
-                      BasicLogService.tweet(
-                        (
-                          "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          + "\nrelying party -- verification testimony matches request parameters" 
-                          + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        )
-                      )
-                      println(
-                        (
-                          "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          + "\nrelying party -- verification testimony matches request parameters" 
-                          + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        )
-                      )
 
-                      BasicLogService.tweet(
+                      logger.debug(
                         (
                           "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          + "\nrelying party -- publishing close claim: " + closeClaim
-                          + "\n on cnxn: " + cnxnWr
-                          + "\n label: " + closeClaim
+                          + "\nrelying party -- verification testimony matches request parameters" 
                           + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                         )
                       )
-                      println(
+                      logger.debug(
                         (
                           "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                           + "\nrelying party -- publishing close claim: " + closeClaim
@@ -226,17 +161,8 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
                         CloseClaim.toLabel( sidOC ),
                         closeClaim
                       )
-                      
-                      BasicLogService.tweet(
-                        (
-                          "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          + "\nrelying party -- publishing VerificationNotification: " + notification
-                          + "\n on cnxn: " + rp2GLoSWr
-                          + "\n label: " + VerificationNotification.toLabel( sidOC )
-                          + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        )
-                      )
-                      println(
+
+                      logger.debug(
                         (
                           "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                           + "\nrelying party -- publishing VerificationNotification: " + notification
@@ -268,14 +194,7 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
                     }
                   }
                   case Right( true ) => {
-                    BasicLogService.tweet(
-                      (
-                        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        + "\nrelying party -- still waiting for verification from verifier"
-                        + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                      )
-                    )
-                    println(
+                    logger.debug(
                       (
                         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                         + "\nrelying party -- still waiting for verification from verifier"
@@ -284,14 +203,7 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
                     )
                   }
                   case _ => {
-                    BasicLogService.tweet(
-                      (
-                        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        + "\nrelying party -- unexpected protocol message : " + eVerification
-                        + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                      )
-                    )
-                    println(
+                    logger.debug(
                       (
                         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                         + "\nrelying party -- unexpected protocol message : " + eVerification
@@ -310,14 +222,7 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
               }
             }
             case Right( true ) => {
-              BasicLogService.tweet(
-                (
-                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  + "\nrelying party -- still waiting for open claim request from relying party"
-                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                )
-              )
-              println(
+              logger.debug(
                 (
                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                   + "\nrelying party -- still waiting for open claim request from relying party"
@@ -326,14 +231,7 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
               )
             }
             case _ => {
-              BasicLogService.tweet(
-                (
-                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  + "\nrelying party -- unexpected protocol message : " + eOpenClaim
-                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                )
-              )
-              println(
+              logger.debug(
                 (
                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                   + "\nrelying party -- unexpected protocol message : " + eOpenClaim
@@ -357,6 +255,9 @@ trait RelyingPartyBehaviorT extends ProtocolBehaviorT with Serializable {
 
 class RelyingPartyBehavior(
 ) extends RelyingPartyBehaviorT {
+
+  val logger = org.slf4j.LoggerFactory.getLogger(classOf[RelyingPartyBehavior])
+
   override def run(
     kvdbNode: Being.AgentKVDBNode[PersistedKVDBNodeRequest, PersistedKVDBNodeResponse],
     cnxns: Seq[PortableAgentCnxn],

--- a/AgentServices-Store/src/main/scala/com/protegra_ati/agentservices/protocols/verification/VerifierBehavior.scala
+++ b/AgentServices-Store/src/main/scala/com/protegra_ati/agentservices/protocols/verification/VerifierBehavior.scala
@@ -21,23 +21,20 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
   import com.biosimilarity.evaluator.distribution.utilities.DieselValueTrampoline._
   import com.protegra_ati.agentservices.store.extensions.StringExtensions._
 
+  /**
+    * Define a logger used within the protocol.
+    * @note You can instantiate one with org.slf4j.LoggerFactory.getLogger(classOf[yourclass])
+    * @return
+    */
+  def logger: org.slf4j.Logger
+
   def run(
     node : Being.AgentKVDBNode[PersistedKVDBNodeRequest, PersistedKVDBNodeResponse],
     cnxns : Seq[PortableAgentCnxn],
     filters : Seq[CnxnCtxtLabel[String, String, String]]
   ): Unit = {
     // BUGBUG : lgm -- move defensive check on args to run method
-    BasicLogService.tweet(
-      (
-        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-        + "\nverifier -- behavior instantiated and run method invoked " 
-        + "\nnode: " + node
-        + "\ncnxns: " + cnxns
-        + "\nfilters: " + filters
-        + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-      )
-    )
-    println(
+    logger.debug(
       (
         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
         + "\nverifier -- behavior instantiated and run method invoked " 
@@ -60,16 +57,7 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
 
     for( cnxnRd <- agntCnxns ) {
       val cnxnWr = acT.AgentCnxn( cnxnRd.src, cnxnRd.label, cnxnRd.trgt )
-      BasicLogService.tweet(
-          (
-            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-            + "\nverifier -- waiting for allow verification request on: " 
-            + "\ncnxn: " + cnxnRd
-            + "\nlabel: " + AllowVerification.toLabel
-            + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-          )
-      )
-      println(
+      logger.debug(
           (
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
             + "\nverifier -- waiting for allow verification request on: " 
@@ -81,17 +69,8 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
       reset {
         for( eAllowV <- node.subscribe( cnxnRd )( AllowVerification.toLabel ) ) {
           rsrc2V[VerificationMessage]( eAllowV ) match {
-            case Left( AllowVerification( sidAV, cidAV, rpAV, clmAV ) ) => { 
-              BasicLogService.tweet(
-                (
-                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  + "\nverifier -- received allow verification request: " + eAllowV
-                  + "\ncnxn: " + cnxnRd
-                  + "\nlabel: " + AllowVerification.toLabel
-                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                )
-              )
-              println(
+            case Left( AllowVerification( sidAV, cidAV, rpAV, clmAV ) ) => {
+              logger.debug(
                 (
                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                   + "\nverifier -- received allow verification request: " + eAllowV
@@ -108,16 +87,7 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
               val acknowledgment =
                 AckAllowVerification( sidAV, cidAV, rpAV, clmAV )
 
-              BasicLogService.tweet(
-                (
-                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  + "\nverifier -- publishing AllowVerification acknowledgment: " + acknowledgment
-                  + "\n on cnxn: " + cnxnWr
-                  + "\n label: " + AllowVerification.toLabel( sidAV )
-                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                )
-              )
-              println(
+              logger.debug(
                 (
                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                   + "\nverifier -- publishing AllowVerification acknowledgment: " + acknowledgment
@@ -132,16 +102,7 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
                 acknowledgment
               )
 
-              BasicLogService.tweet(
-                (
-                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  + "\nverifier -- waiting for verify request on: " 
-                  + "\ncnxn: " + agntRPWr
-                  + "\nlabel: " + Verify.toLabel
-                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                )
-              )
-              println(
+              logger.debug(
                 (
                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                   + "\nverifier -- waiting for verify request on: " 
@@ -153,17 +114,8 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
 
               for( eVerify <- node.subscribe( agntRPWr )( Verify.toLabel ) ) {
                 rsrc2V[VerificationMessage]( eVerify ) match {
-                  case Left( Verify( sidV, cidV, clmntV, clmV ) ) => { 
-                    BasicLogService.tweet(
-                      (
-                        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        + "\nverifier -- received verification request: " + eVerify
-                        + "\ncnxn: " + agntRPRd
-                        + "\nlabel: " + Verify.toLabel
-                        + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                      )
-                    )
-                    println(
+                  case Left( Verify( sidV, cidV, clmntV, clmV ) ) => {
+                    logger.debug(
                       (
                         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                         + "\nverifier -- received verification request: " + eVerify
@@ -188,15 +140,8 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
                           sidV, cidV, clmntV, clmV,
                           "claimVerified( true )".toLabel
                         )
-                      
-                      BasicLogService.tweet(
-                        (
-                          "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          + "\nverifier -- verification request matches permission parameters" 
-                          + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        )
-                      )
-                      println(
+
+                      logger.debug(
                         (
                           "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                           + "\nverifier -- verification request matches permission parameters" 
@@ -204,16 +149,7 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
                         )
                       )
 
-                      BasicLogService.tweet(
-                        (
-                          "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          + "\nverifier -- publishing Verification testimony: " + verification
-                          + "\n on cnxn: " + agntRPWr
-                          + "\n label: " + Verification.toLabel( sidAV )
-                          + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        )
-                      )
-                      println(
+                      logger.debug(
                         (
                           "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                           + "\nverifier -- publishing Verification testimony: " + verification
@@ -228,16 +164,7 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
                         verification
                       )
 
-                      BasicLogService.tweet(
-                        (
-                          "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          + "\nverifier -- publishing VerificationNotification: " + notification
-                          + "\n on cnxn: " + agntRPRd
-                          + "\n label: " + VerificationNotification.toLabel( sidAV )
-                          + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        )
-                      )
-                      println(
+                      logger.debug(
                         (
                           "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                           + "\nverifier -- publishing VerificationNotification: " + notification
@@ -264,16 +191,7 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
                           "protocolError(\"unexpected verify message data\")".toLabel
                         )
 
-                      BasicLogService.tweet(
-                        (
-                          "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          + "\nverifier -- publishing Verification disengagement: " + verification
-                          + "\n on cnxn: " + agntRPWr
-                          + "\n label: " + Verification.toLabel( sidAV )
-                          + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        )
-                      )
-                      println(
+                      logger.debug(
                         (
                           "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                           + "\nverifier -- publishing Verification disengagement: " + verification
@@ -286,17 +204,8 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
                         Verification.toLabel( sidAV ),
                         verification
                       )
-                      
-                      BasicLogService.tweet(
-                        (
-                          "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                          + "\nverifier -- publishing VerificationNotification: " + notification
-                          + "\n on cnxn: " + agntRPWr
-                          + "\n label: " + VerificationNotification.toLabel( sidAV )
-                          + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        )
-                      )
-                      println(
+
+                      logger.debug(
                         (
                           "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                           + "\nverifier -- publishing VerificationNotification: " + notification
@@ -313,14 +222,7 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
                     }
                   }
                   case Right( true ) => {
-                    BasicLogService.tweet(
-                      (
-                        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        + "\nverifier -- still waiting for verify request"
-                        + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                      )
-                    )
-                    println(
+                    logger.debug(
                       (
                         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                         + "\nverifier -- still waiting for verify request"
@@ -340,31 +242,14 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
                         ).toLabel
                       )
 
-                    BasicLogService.tweet(
+                    logger.debug(
                       (
                         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                         + "\nverifier -- unexpected protocol message : " + eVerify
                         + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                       )
                     )
-                    println(
-                      (
-                        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        + "\nverifier -- unexpected protocol message : " + eVerify
-                        + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                      )
-                    )
-
-                    BasicLogService.tweet(
-                      (
-                        "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                        + "\nverifier -- publishing VerificationNotification: " + notification
-                        + "\n on cnxn: " + agntRPWr
-                        + "\n label: " + VerificationNotification.toLabel
-                        + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                      )
-                    )
-                    println(
+                    logger.debug(
                       (
                         "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                         + "\nverifier -- publishing VerificationNotification: " + notification
@@ -383,14 +268,7 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
               }
             }
             case Right( true ) => {
-              BasicLogService.tweet(
-                (
-                  "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                  + "\nverifier -- still waiting for claim initiation"
-                  + "\n||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
-                )
-              )
-              println(
+              logger.debug(
                 (
                   "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
                   + "\nverifier -- still waiting for claim initiation"
@@ -399,9 +277,7 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
               )
             }
             case _ => {
-              BasicLogService.tweet( "unexpected protocol message : "
-                      + eAllowV )
-              println( "unexpected protocol message : " + eAllowV )
+              logger.error( "unexpected protocol message : " + eAllowV )
               node.publish( vrfr2GLoSWr )(
                 VerificationNotification.toLabel(),
                 VerificationNotification(
@@ -422,6 +298,9 @@ trait VerifierBehaviorT extends ProtocolBehaviorT with Serializable {
 
 class VerifierBehavior(
 ) extends VerifierBehaviorT {
+
+  val logger = org.slf4j.LoggerFactory.getLogger(classOf[VerifierBehavior])
+
   override def run(
     kvdbNode: Being.AgentKVDBNode[PersistedKVDBNodeRequest, PersistedKVDBNodeResponse],
     cnxns: Seq[PortableAgentCnxn],


### PR DESCRIPTION
This commit takes advantage of SLF4J's call-by-name input parameter to provide performance improvements when creating debug log output. The log string is only evaluated when log output is set to `DEBUG`.